### PR TITLE
enable to add user_hash in user context

### DIFF
--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -21,13 +21,18 @@ export default Service.extend({
     return get(this, `user.${get(this, 'config.userProperties.emailProp')}`);
   }),
 
+  _userHashProp: computed('config.userProperties.hashProp', function() {
+    return get(this, `user.${get(this, 'config.userProperties.hashProp')}`);
+  }),
+
   _userCreatedAtProp: computed('config.userProperties.createdAtProp', function() {
     return get(this, `user.${get(this, 'config.userProperties.createdAtProp')}`);
   }),
 
   user: {
     name: null,
-    email: null
+    email: null,
+    hash: null
   },
 
   _hasUserContext: computed('user', '_userNameProp', '_userEmailProp', '_userCreatedAtProp', function() {
@@ -47,6 +52,10 @@ export default Service.extend({
     if (get(this, '_hasUserContext')) {
       obj.name = get(this, '_userNameProp');
       obj.email = get(this, '_userEmailProp');
+      if (get(this, '_userHashProp')) {
+        // eslint-disable-next-line
+        obj.user_hash = get(this, '_userHashProp');
+      }
       if (get(this, '_userCreatedAtProp')) {
         // eslint-disable-next-line
         obj.created_at = get(this, '_userCreatedAtProp');

--- a/config/environment.js
+++ b/config/environment.js
@@ -7,6 +7,7 @@ module.exports = function(/* environment, appConfig */) {
       userProperties: {
         nameProp: 'name',
         emailProp: 'email',
+        hashProp: 'hash',
         createdAtProp: 'createdAt'
       }
     }

--- a/tests/integration/components/intercom-io-test.js
+++ b/tests/integration/components/intercom-io-test.js
@@ -23,6 +23,7 @@ const mockConfig = {
     userProperties: {
       nameProp: 'name',
       emailProp: 'email',
+      hashProp: 'hash',
       createdAtProp: 'createdAt'
     },
     appId: '1'

--- a/tests/unit/services/intercom-test.js
+++ b/tests/unit/services/intercom-test.js
@@ -13,6 +13,7 @@ const mockConfig = {
     userProperties: {
       nameProp: 'name',
       emailProp: 'email',
+      hashProp: 'hash',
       createdAtProp: 'createdAt'
     },
     appId: '1'


### PR DESCRIPTION
Enable to add user_hash to verify user identity

https://docs.intercom.com/configure-intercom-for-your-product-or-site/staying-secure/enable-identity-verification-on-your-web-product