### PR TITLE
Advanced Intercom API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![devDependency Status](https://david-dm.org/mike-north/ember-intercom-io/dev-status.svg)](https://david-dm.org/mike-north/ember-intercom-io#info=devDependencies)
 [![Ember Observer Score](http://emberobserver.com/badges/ember-intercom-io.svg)](http://emberobserver.com/addons/ember-intercom-io)
 
-[Intercom.io](http://intercom.io) for Ember.js apps. 
+[Intercom.io](http://intercom.io) for Ember.js apps.
 
 ## Setup
 
@@ -58,6 +58,74 @@ export default Ember.Service.extend({
 });
 
 ```
+
+## API
+
+The `intercom` service exposes several public API methods that match Intercom.com's
+existing Javascript API. For full details on the client API, [read the Intercom docs.](https://developers.intercom.com/v2.0/docs/intercom-javascript#section-intercomonhide)
+
+### Properties
+
+|    Name      |      Type         |
+------------------------------------
+| autoUpdate   | Boolean           |
+| hideDefaultLauncher | Boolean    |
+| isOpen       | Boolean           |
+| isBooted     | Boolean           |
+| unreadCount  | Integer           |
+| user         | Object            |
+
+### Methods
+
+The following intercom methods are implemented. See `services/intercom.js` for full
+details.
+
+`boot()`
+
+`update()`
+
+`shutdown()`
+
+`hide()`
+
+`show()`
+
+`showMessages()`
+
+`showNewMessage()`
+
+`trackEvent()`
+
+`getVisitorId()` Returns the current id of the logged in user.
+
+### Events
+
+Subscribe to events in your app with event listeners:
+
+```js
+//fancy-component.js
+
+...
+
+intercom: Ember.inject.service(),
+newMessageAlert: Ember.on('intercom.unreadCountChange', function() {
+    alert('Unread Count Changed!');
+}),
+
+...
+
+```
+
+**Available Events**
+
+(Read the Intercom documentation for full details)[https://developers.intercom.com/v2.0/docs/intercom-javascript#section-intercomonhide]
+
+| Ember Event | Intercom Event |
+--------------------------------
+| hide        | `onHide`       |
+| show        | `onShow`       |
+| unreadCountChange | `onUnreadCountChange` |
+
 
 ## Installation
 

--- a/addon/mixins/intercom-route.js
+++ b/addon/mixins/intercom-route.js
@@ -1,0 +1,23 @@
+import Mixin from '@ember/object/mixin';
+import { inject as service } from '@ember/service';
+import { on } from '@ember/object/evented';
+import { get } from '@ember/object';
+import { assert } from '@ember/debug';
+
+export default Mixin.create({
+  intercom: service(),
+  /**
+   * push page changes to intercom
+   * @private
+   * @on didTransition
+   */
+  submitRouteChange: on('didTransition', function() {
+    let intercom = get(this, 'intercom');
+
+    assert('Could not find property configured intercom instance', intercom);
+
+    if (get(intercom, 'isBooted')) {
+      intercom.update();
+    }
+  })
+});

--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -6,6 +6,7 @@ import intercom from 'intercom';
 import { run } from '@ember/runloop';
 import { typeOf } from "@ember/utils";
 import { underscore } from "@ember/string"	;
+import Evented from '@ember/object/evented';
 
 
 /**
@@ -38,7 +39,7 @@ function normalizeIntercomMetadata(data) {
   return result;
 }
 
-export default Service.extend({
+export default Service.extend(Evented, {
   init() {
     this._super(...arguments);
     set(this, 'user', { email: null, name: null, hash: null, user_id: null });

--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -7,6 +7,7 @@ import { run } from '@ember/runloop';
 import { typeOf } from "@ember/utils";
 import { underscore } from "@ember/string"	;
 import Evented from '@ember/object/evented';
+import { alias } from '@ember/object/computed';
 
 
 /**
@@ -114,18 +115,21 @@ export default Service.extend(Evented, {
   hideDefaultLauncher: false,
 
   /**
-   * @pri
+   * @private
+   * alias for appId
+   * @type {[type]}
+   */
+  appId: alias('config.appId'),
+
+  /**
+   * Alias for computed user data with app-provided config values
+   * @private
    * @type {[type]}
    */
   _computedUser: computed('user.@each', '_userHashProp', '_userIdProp',
     '_userNameProp', '_userEmailProp', '_userCreatedAtProp', function() {
-      let appId = get(this, 'config.appId');
-      assert('You must supply an "ENV.intercom.appId" in your "config/environment.js" file.', appId);
-
-      let obj = {
-        app_id: appId // eslint-disable-line
-      };
-
+      assert('You must supply an "ENV.intercom.appId" in your "config/environment.js" file.', this.get('appId'));
+      let obj = {}
       if (get(this, '_hasUserContext')) {
 
         let userProps = Object.values(get(this, 'config.userProperties')),
@@ -158,12 +162,6 @@ export default Service.extend(Evented, {
       return obj;
   }),
 
-
-/**
- *
- * @type {Object}
- */
-
   /**
    * Boot interom window
    * @param  {Object} [config={}] [description]
@@ -182,7 +180,7 @@ export default Service.extend(Evented, {
    */
   update(config = {}) {
     if (!this.get('isBooted')) {
-      warn('Cannot call update before boot');
+        ('Cannot call update before boot');
       return;
     }
 
@@ -343,7 +341,8 @@ export default Service.extend(Evented, {
   userDataDidChange: observer('user.@each', function() {
     if (this.get('autoUpdate') && this.get('isBooted')) {
       let user = this.get('_computedUser');
-      let config = { ...user };
+      let appId = this.get('appId')
+      let config = {appId, ...user };
       this.update(config);
     }
   }),

--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -1,18 +1,54 @@
-import { merge } from '@ember/polyfills';
 import Service from '@ember/service';
-import { computed, get, set } from '@ember/object';
-import { assert } from '@ember/debug';
+import { computed, get, set, observer } from '@ember/object';
+import { assert, warn } from '@ember/debug';
 import { scheduleOnce } from '@ember/runloop';
 import intercom from 'intercom';
+import { run } from '@ember/runloop';
+import { typeOf } from "@ember/utils";
+import { underscore } from "@ember/string"	;
+
+
+/**
+ * Normalization function for converting intercom data to a consistent format.
+ *
+ * Changes:
+ * - underscore keys
+ * - convert dates to unix timestamps
+ *
+ * @param  {Object} data
+ *
+ * @private
+ * @return {Object}
+ */
+function normalizeIntercomMetadata(data) {
+  let result = {};
+  let val;
+  Object.keys(data).forEach((key) => {
+    val = data[key];
+    if (typeOf(val) === 'object') {
+      result[underscore(key)] = normalizeIntercomMetadata(val);
+    } else {
+      if (typeOf(val) === 'date') {
+        val = val.valueOf();
+      }
+      result[underscore(key)] = val;
+    }
+  });
+
+  return result;
+}
 
 export default Service.extend({
   init() {
     this._super(...arguments);
-    set(this, "user", { email: null, name: null, hash: null, user_id: null });
+    set(this, 'user', { email: null, name: null, hash: null, user_id: null });
   },
 
   api: intercom,
-
+  /**
+   * [description]
+   * @return {[type]} [description]
+   */
   _userHashProp: computed('config.userProperties.userHashProp', function() {
     return get(this, `user.${get(this, 'config.userProperties.userHashProp')}`);
   }),
@@ -35,42 +71,305 @@ export default Service.extend({
 
   user: null,
 
+  /**
+  * Indicates the open state of the Intercom panel
+  *
+  * @public
+  * @type {Boolean}
+  */
+   isOpen: false,
+
+   /**
+    * Indicates whether the Intercom boot command has been called.
+    *
+    * @public
+    * @readonly
+    * @type {Boolean}
+    */
+   isBooted: false,
+
+   /**
+    * Reports the number of unread messages
+    *
+    * @public
+    * @type {Number}
+    */
+   unreadCount: 0,
+
+   /**
+    * If true, will automatically update intercom when changes to user object are made.
+    *
+    * @type {Boolean}
+    * @public
+    */
+   autoUpdate: true,
+
+   /**
+    * Hide the default Intercom launcher button
+    *
+    * @public
+    * @type {Boolean}
+    */
+  hideDefaultLauncher: false,
+
+  /**
+   * @pri
+   * @type {[type]}
+   */
+  _computedUser: computed('user.@each', '_userHashProp', '_userIdProp',
+    '_userNameProp', '_userEmailProp', '_userCreatedAtProp', function() {
+      let appId = get(this, 'config.appId');
+      assert('You must supply an "ENV.intercom.appId" in your "config/environment.js" file.', appId);
+
+      let obj = {
+        app_id: appId // eslint-disable-line
+      };
+
+      if (get(this, '_hasUserContext')) {
+
+        let userProps = Object.values(get(this, 'config.userProperties')),
+            user = get(this, 'user');
+
+        let userKeys = Object.keys(user);
+
+        userKeys.forEach(k => {
+          if (!userProps.includes(k)) {
+            obj[k] = user[k];
+          }
+        });
+
+        obj.user_hash = get(this, '_userHashProp');
+        obj.user_id = get(this, '_userIdProp');
+        obj.name = get(this, '_userNameProp');
+        obj.email = get(this, '_userEmailProp');
+        if (get(this, '_userCreatedAtProp')) {
+          // eslint-disable-next-line
+          obj.created_at = get(this, '_userCreatedAtProp');
+        }
+
+      }
+
+      for (let prop in obj) {
+        if (typeOf(obj[prop]) === 'undefined') {
+          delete obj[prop];
+        }
+      }
+      return obj;
+  }),
+
+
+/**
+ *
+ * @type {Object}
+ */
+
+  /**
+   * Boot interom window
+   * @param  {Object} [config={}] [description]
+   * @public
+   */
+  boot(config = {}) {
+    this._callIntercomMethod('boot', normalizeIntercomMetadata(config));
+    this._addEventHandlers();
+    this.set('isBooted', true);
+  },
+
+  /**
+   * Update intercom data
+   * @param  {Object} [config={}] [description]
+   * @public
+   */
+  update(config = {}) {
+    if (!this.get('isBooted')) {
+      warn('Cannot call update before boot');
+      return;
+    }
+
+    let _hasUserContext = this.get('_hasUserContext');
+    if (_hasUserContext) {
+      this._callIntercomMethod('update', normalizeIntercomMetadata(config));
+    } else {
+      warn('Refusing to send update to Intercom because user context is incomplete. Missing userId or email');
+    }
+  },
+
+  /**
+   * shutdown Intercom window
+   * @public
+   */
+  shutdown() {
+    this.set('isBooted', false);
+    this._hasEventHandlers = false;
+    this._callIntercomMethod('shutdown');
+  },
+
+  /**
+   * Show intercom window
+   * @public
+   */
+  show() {
+    return this._wrapIntercomCallInPromise('show', 'show');
+  },
+
+  /**
+  * hide intercom window
+  * @public
+  */
+  hide() {
+    return this._wrapIntercomCallInPromise('hide', 'hide');
+  },
+
+  toggleOpen() {
+    this.get('isOpen') ? this.hide() : this.show();
+  },
+
+  /**
+   * Opens the message window with the message list visible.
+   *
+   * @public
+   * @return {Promise}
+   */
+  showMessages() {
+    return this._wrapIntercomCallInPromise('showMessages', 'show');
+  },
+
+  /**
+   * Opens the message window with the new message view.
+   *
+   * @public
+   * @return {Promise}
+   */
+  showNewMessage(initialText) {
+    return this._wrapIntercomCallInPromise('showNewMessage', 'show', initialText);
+  },
+
+  /**
+   * You can submit an event using the trackEvent method.
+   * This will associate the event with the currently logged in user and
+   * send it to Intercom.
+   *
+   * The final parameter is a map that can be used to send optional
+   * metadata about the event.
+   *
+   * @param {String} eventName
+   * @param {Object} metadata
+   * @public
+   */
+  trackEvent() {
+    this._callIntercomMethod('trackEvent', ...arguments);
+  },
+
+  /**
+   * A visitor is someone who goes to your site but does not use the messenger.
+   * You can track these visitors via the visitor user_id. This user_id
+   * can be used to retrieve the visitor or lead through the REST API.
+   *
+   * @public
+   * @return {String} The visitor ID
+   */
+  getVisitorId() {
+    return this.get('api')('getVisitorId');
+  },
+
+  start(bootConfig = {}) {
+    let config = get(this, '_intercomBootConfig');
+    bootConfig = {...bootConfig, ...config}
+    return this.boot(bootConfig);
+  },
+
+  stop() {
+    return this.shutdown();
+  },
+
+  /**
+   * Private on hide
+   * @private
+   * @return {[type]} [description]
+   */
+  _onHide() {
+    this.set('isOpen', false);
+    this.trigger('hide');
+  },
+
+  /**
+   * handle onShow events
+   * @private
+   */
+  _onShow() {
+    this.set('isOpen', true);
+    this.trigger('show');
+  },
+
+  /**
+  * Handle onUnreadCountChange Events
+  * @param  {[type]} count [description]
+  * @private
+  */
+  _onUnreadCountChange(count) {
+    this.set('unreadCount', Number(count));
+  },
+
+  _addEventHandlers() {
+    if (this._hasEventHandlers) {
+      return;
+    }
+    this._callIntercomMethod('onHide', () => run(this, this._onHide));
+    this._callIntercomMethod('onShow', () => run(this, this._onShow));
+    this._callIntercomMethod('onUnreadCountChange', (count) => run(this, this._onUnreadCountChange, count));
+    this._hasEventHandlers = true;
+  },
+
+  _wrapIntercomCallInPromise(intercomMethod, eventName, ...args) {
+    return new Promise((resolve) => {
+      let isOpen = this.get('isOpen');
+      if (eventName === 'show' && isOpen
+          || eventName === 'hide' && !isOpen) {
+        run.next(this, resolve);
+      } else {
+        this.one(eventName, resolve);
+      }
+      this._callIntercomMethod(intercomMethod, ...args);
+    });
+  },
+
+  _callIntercomMethod(methodName, ...args) {
+    scheduleOnce('afterRender', () => {
+      let intercom = this.get('api');
+      intercom(methodName, ...args);
+    });
+  },
+
+  userDataDidChange: observer('user.@each', function() {
+    if (this.get('autoUpdate') && this.get('isBooted')) {
+      let user = this.get('_computedUser');
+      let config = { ...user };
+      this.update(config);
+    }
+  }),
+
   _hasUserContext: computed('user', '_userNameProp', '_userEmailProp', '_userCreatedAtProp', function() {
     return !!get(this, 'user') && !!get(this, '_userNameProp') &&
       (!!get(this, '_userEmailProp') || !!get(this, "_userIdProp"));
   }),
 
-  _intercomBootConfig: computed('_hasUserContext', function() {
+  _intercomBootConfig: computed('config','user.@each', '_hasUserContext', 'hideDefaultLauncher', function() {
     let appId = get(this, 'config.appId');
+    let user = get(this, '_computedUser');
+    let _hasUserContext = get(this, '_hasUserContext');
+    let hideDefaultLauncher = get(this, 'hideDefaultLauncher');
+
     assert('You must supply an "ENV.intercom.appId" in your "config/environment.js" file.', appId);
 
-    let obj = {
-      app_id: appId // eslint-disable-line
-    };
-
-    if (get(this, '_hasUserContext')) {
-      obj.user_hash = get(this, '_userHashProp');
-      obj.user_id = get(this, '_userIdProp');
-      obj.name = get(this, '_userNameProp');
-      obj.email = get(this, '_userEmailProp');
-      if (get(this, '_userCreatedAtProp')) {
-        // eslint-disable-next-line
-        obj.created_at = get(this, '_userCreatedAtProp');
-      }
+    let obj = { appId };
+    if (hideDefaultLauncher) {
+      obj.hideDefaultLauncher = true;
     }
+
+    if (_hasUserContext) {
+      obj = { ...obj, ...user };
+    }
+
     return obj;
-  }),
+  })
 
-  start(bootConfig = {}) {
-    let _bootConfig = merge(get(this, '_intercomBootConfig'), bootConfig);
-    scheduleOnce('afterRender', () => this.get('api')('boot', _bootConfig));
-  },
-
-  stop() {
-    scheduleOnce('afterRender', () => this.get('api')('shutdown'));
-  },
-
-  update(properties = {}) {
-    scheduleOnce('afterRender', () => this.get('api')('update', properties));
-  }
 });

--- a/index.js
+++ b/index.js
@@ -5,7 +5,11 @@ var path = require('path');
 
 module.exports = {
   name: 'ember-intercom-io',
-
+  options: {
+    babel: {
+      plugins: ['transform-object-rest-spread']
+    }
+  },
   included: function(app) {
     this._super.included(app);
     app.import('vendor/intercom-shim.js');

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "chat"
   ],
   "dependencies": {
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1"
   },

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -33,7 +33,7 @@ module.exports = function(environment) {
       'style-src': ['http://localhost:4200', "'unsafe-inline'"].join(' ')
     },
     intercom: {
-      appId: 'e8moi2hb'
+      appId: 'asdfasdf'
     },
     APP: {
       // Here you can pass flags/options to your application instance

--- a/yarn.lock
+++ b/yarn.lock
@@ -575,6 +575,10 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -762,6 +766,13 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"


### PR DESCRIPTION
@ivanvanderbyl  - rather than sort of a year's worth of merge conflicts, I just started over. 

This PR: 

- [x] Exposes the full intercom javascript API to the `intercom` service
- [x] Adds a route transition mixin to track page loads (if you don't use `ember-metrics`
- [x] Adds additional properties that match intercom data to the intercom service
- [x] Tests pass on my machine...

This is all the same stuff as #94  and #80 