### PR TITLE
add trackevent method

### DIFF
--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -72,5 +72,9 @@ export default Service.extend({
 
   update(properties = {}) {
     scheduleOnce('afterRender', () => this.get('api')('update', properties));
+  },
+
+  trackEvent(name, metaData = {}) {
+    scheduleOnce('afterRender', () => this.get('api')('trackEvent', name, metaData));
   }
 });


### PR DESCRIPTION
adds a method to track events, call it like this `get(this, 'intercom').trackEvent('name', optional metadata {});`