### PR TITLE
trigger `unreadCountChange`

### DIFF
--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -277,6 +277,7 @@ export default Service.extend(Evented, {
    */
   _onUnreadCountChange(count) {
     this.set('unreadCount', Number(count));
+    this.trigger('unreadCountChange');
   },
 
   _addEventHandlers() {


### PR DESCRIPTION
The documentation seems to suggest that doing

```js
onIntercomUnreadCountChange: on('intercom.unreadCountChange', function() {
  // your code here
})
```

should be possible, but the service wasn't triggering the event at all.