### PR TITLE
fix: Fixing bug where isBooted is incorrectly set to true

### DIFF
--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -141,13 +141,17 @@ export default Service.extend(Evented, {
 
   /**
    * Boot intercom window
+   * Set isBooted to true if Intercom is booted, and false if intercom is prevented to boot from third party tracking blockers, e.g. "Disconnect"
+   *
    * @param  {Object} [config={}] [description]
    * @public
    */
   boot(config = {}) {
     this._callIntercomMethod('boot', normalizeIntercomMetadata(config));
     this._addEventHandlers();
-    this.set('isBooted', true);
+    if (window.Intercom) {
+      this.set('isBooted', window.Intercom.booted)
+    }
   },
 
   /**


### PR DESCRIPTION
fix: Fixing bug where isBooted is set to true even if Intercom is prevented to boot from third party tracking blockers, e.g. "Disconnect"