### PR TITLE
Add survey support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ details.
 
 `startTour()` Your intercom account needs to support product tours
 
+`startSurvey()`
+
 ### Events
 
 Subscribe to events in your app with event listeners:

--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -264,6 +264,19 @@ export default Service.extend(Evented, {
   },
 
   /**
+   * If you would like to trigger a survey based on an action a user or visitor
+   * takes in your site or application, you can use this API method.
+   * You need to call this method with the id of the survey you wish to show.
+   * The id of the survey can be found in the “Additional ways to share your
+   * survey” section of the survey editor as well as in the URL of the editor.
+   * @public
+   * @param  {number} surveyId Survey ID to trigger
+   */
+  startSurvey(surveyId) {
+    return this.get('api')('startSurvey', surveyId);
+  },
+
+  /**
    * Private on hide
    * @private
    * @return {[type]} [description]

--- a/tests/unit/services/intercom-test.js
+++ b/tests/unit/services/intercom-test.js
@@ -144,5 +144,9 @@ module('Unit | Service | intercom', function(hooks) {
     service.startTour(123);
     assert.equal(intercomStub.calledWith('startTour'), true, 'Intercom method called -- startTour');
     sinon.assert.calledWith(intercomStub, 'startTour', 123);
+
+    service.startSurvey(456);
+    assert.equal(intercomStub.calledWith('startSurvey'), true, 'Intercom method called -- startSurvey');
+    sinon.assert.calledWith(intercomStub, 'startSurvey', 456);
   });
 });


### PR DESCRIPTION
Similarly to https://github.com/mike-north/ember-intercom-io/pull/300, this just exposes Intercom's JS API's [`startSurvey` method](https://developers.intercom.com/installing-intercom/docs/intercom-javascript#intercomstartsurvey-surveyid).