### PR TITLE
feat: add support for startSurvey function

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ details.
 
 `startTour()` Your intercom account needs to support product tours
 
+`startSurvey()` Your intercom account needs to support surveys
+
 ### Events
 
 Subscribe to events in your app with event listeners:

--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -264,6 +264,20 @@ export default Service.extend(Evented, {
   },
 
   /**
+   * If you would like to trigger a survey based on an action a user or visitor
+   * takes in your site or application, you can use this API method.
+   * You need to call this method with the id of the survey you wish to show.
+   * The id of the survey can be found in the “Additional ways to share your survey”
+   * section of the survey editor.
+   * @public
+   * @param  {number} surveyId Survey ID to trigger
+   */
+    startSurvey(surveyId) {
+      return this.get('api')('startSurvey', surveyId);
+    },
+  
+
+  /**
    * Private on hide
    * @private
    * @return {[type]} [description]

--- a/tests/unit/services/intercom-test.js
+++ b/tests/unit/services/intercom-test.js
@@ -144,5 +144,9 @@ module('Unit | Service | intercom', function(hooks) {
     service.startTour(123);
     assert.equal(intercomStub.calledWith('startTour'), true, 'Intercom method called -- startTour');
     sinon.assert.calledWith(intercomStub, 'startTour', 123);
+
+    service.startSurvey(456);
+    assert.equal(intercomStub.calledWith('startSurvey'), true, 'Intercom method called -- startSurvey');
+    sinon.assert.calledWith(intercomStub, 'startSurvey', 456);
   });
 });


### PR DESCRIPTION
Added support for startSurvey in intercom's api:

https://developers.intercom.com/installing-intercom/web/methods/#intercomstartsurvey-surveyid