### PR TITLE
Fix assign from @ember/polyfills deprecation

### DIFF
--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import Service from '@ember/service';
 import { computed, get, observer, set } from '@ember/object';
 import { assert, warn } from '@ember/debug';
@@ -28,7 +27,7 @@ const WarnOption = {
 function normalizeIntercomMetadata(data) {
   let result = {};
   let val;
-  Object.keys(data).forEach(key => {
+  Object.keys(data).forEach((key) => {
     val = data[key];
     if (typeOf(val) === 'object') {
       result[underscore(key)] = normalizeIntercomMetadata(val);
@@ -57,23 +56,23 @@ export default Service.extend(Evented, {
    * [description]
    * @return {[type]} [description]
    */
-  _userHashProp: computed('user', 'config.userProperties.userHashProp', function() {
+  _userHashProp: computed('user', 'config.userProperties.userHashProp', function () {
     return get(this, `user.${get(this, 'config.userProperties.userHashProp')}`);
   }),
 
-  _userIdProp: computed('user', 'config.userProperties.userIdProp', function() {
+  _userIdProp: computed('user', 'config.userProperties.userIdProp', function () {
     return get(this, `user.${get(this, 'config.userProperties.userIdProp')}`);
   }),
 
-  _userNameProp: computed('user', 'config.userProperties.nameProp', function() {
+  _userNameProp: computed('user', 'config.userProperties.nameProp', function () {
     return get(this, `user.${get(this, 'config.userProperties.nameProp')}`);
   }),
 
-  _userEmailProp: computed('user', 'config.userProperties.emailProp', function() {
+  _userEmailProp: computed('user', 'config.userProperties.emailProp', function () {
     return get(this, `user.${get(this, 'config.userProperties.emailProp')}`);
   }),
 
-  _userCreatedAtProp: computed('user', 'config.userProperties.createdAtProp', function() {
+  _userCreatedAtProp: computed('user', 'config.userProperties.createdAtProp', function () {
     return get(this, `user.${get(this, 'config.userProperties.createdAtProp')}`);
   }),
 
@@ -93,11 +92,8 @@ export default Service.extend(Evented, {
    * @type {Boolean}
    */
   isBooted: false,
-  _hasUserContext: computed('user', '_userEmailProp', '_userIdProp', function() {
-    return (
-      !!get(this, 'user') &&
-      (!!get(this, '_userEmailProp') || !!get(this, '_userIdProp'))
-    );
+  _hasUserContext: computed('user', '_userEmailProp', '_userIdProp', function () {
+    return !!get(this, 'user') && (!!get(this, '_userEmailProp') || !!get(this, '_userIdProp'));
   }),
   /**
    * Reports the number of unread messages
@@ -131,7 +127,7 @@ export default Service.extend(Evented, {
   appId: alias('config.appId'),
 
   start(bootConfig = {}) {
-    let _bootConfig = assign(get(this, '_intercomBootConfig'), bootConfig);
+    let _bootConfig = Object.assign(get(this, '_intercomBootConfig'), bootConfig);
     this.boot(_bootConfig);
   },
 
@@ -297,14 +293,14 @@ export default Service.extend(Evented, {
     }
     this._callIntercomMethod('onHide', () => next(this, '_onHide'));
     this._callIntercomMethod('onShow', () => next(this, '_onShow'));
-    this._callIntercomMethod('onUnreadCountChange', count => {
+    this._callIntercomMethod('onUnreadCountChange', (count) => {
       this._onUnreadCountChange(count);
     });
     this._hasEventHandlers = true;
   },
 
   _wrapIntercomCallInPromise(intercomMethod, eventName, ...args) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       let isOpen = this.get('isOpen');
       if ((eventName === 'show' && isOpen) || (eventName === 'hide' && !isOpen)) {
         next(this, resolve);
@@ -321,11 +317,11 @@ export default Service.extend(Evented, {
   },
 
   // eslint-disable-next-line ember/no-observers
-  userDataDidChange: observer('user.@each', function() {
+  userDataDidChange: observer('user.@each', function () {
     if (this.get('autoUpdate') && this.get('isBooted')) {
       let user = this.get('_computedUser');
       let appId = this.get('appId');
-      let config = assign({ app_id: appId}, user );
+      let config = Object.assign({ app_id: appId }, user);
       this.update(config);
     }
   }),
@@ -343,7 +339,7 @@ export default Service.extend(Evented, {
     '_userNameProp',
     '_userEmailProp',
     '_userCreatedAtProp',
-    function() {
+    function () {
       assert('You must supply an "ENV.intercom.appId" in your "config/environment.js" file.', this.get('appId'));
 
       let obj = {};
@@ -352,7 +348,7 @@ export default Service.extend(Evented, {
           user = get(this, 'user'),
           userKeys = Object.keys(user);
 
-        userKeys.forEach(k => {
+        userKeys.forEach((k) => {
           if (!userProps.includes(k) && !obj.hasOwnProperty(k)) {
             obj[k] = user[k];
           }
@@ -371,7 +367,7 @@ export default Service.extend(Evented, {
     }
   ),
 
-  _intercomBootConfig: computed('config', 'user.@each', '_hasUserContext', 'hideDefaultLauncher', function() {
+  _intercomBootConfig: computed('config', 'user.@each', '_hasUserContext', 'hideDefaultLauncher', function () {
     let appId = get(this, 'config.appId');
     let user = get(this, '_computedUser');
     let _hasUserContext = get(this, '_hasUserContext');
@@ -385,7 +381,7 @@ export default Service.extend(Evented, {
     }
 
     if (_hasUserContext) {
-      obj = assign({}, obj, user);
+      obj = Object.assign({}, obj, user);
     }
 
     return normalizeIntercomMetadata(obj);

--- a/package.json
+++ b/package.json
@@ -84,5 +84,9 @@
   },
   "release": {
     "extends": "@mike-north/js-lib-semantic-release-config"
+  },
+  "volta": {
+    "node": "16.20.2",
+    "yarn": "1.22.22"
   }
 }


### PR DESCRIPTION
Fixes `import { assign } from '@ember/polyfills';` deprecation. Required for Ember 5.